### PR TITLE
fix: Spring Security로 인한 정적 자원(부트스트랩) 접근 문제 해결

### DIFF
--- a/src/main/java/org/servlet2spring/todo/config/CustomSecurityConfig.java
+++ b/src/main/java/org/servlet2spring/todo/config/CustomSecurityConfig.java
@@ -71,9 +71,11 @@ public class CustomSecurityConfig {
                     session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
             )
             .authorizeHttpRequests(auth ->
-                    auth.requestMatchers("/error", "/login", "/swagger-ui/**", "/v3/api-docs/**", "/board/**").permitAll()
-                    .anyRequest().authenticated()
-    );
+                    auth.requestMatchers("/error", "/login", "/swagger-ui/**", "/v3/api-docs/**").permitAll()
+                            .requestMatchers("/assets/**","/css/**","/js/**").permitAll() // bootstrap
+                            .requestMatchers("/board/**", "/replies/**", "/view/**", "/upload/**").permitAll()  // board
+
+            );
 
     return http.build();
   }

--- a/src/main/java/org/servlet2spring/todo/config/CustomServletConfig.java
+++ b/src/main/java/org/servlet2spring/todo/config/CustomServletConfig.java
@@ -11,6 +11,8 @@ public class CustomServletConfig implements WebMvcConfigurer {
 
   @Override
   public void addResourceHandlers(ResourceHandlerRegistry registry) {
-    registry.addResourceHandler("/board/**").addResourceLocations("/resources/");
+    registry.addResourceHandler("/assets/**", "/css/**", "/js/**", "/upload/**")
+            .addResourceLocations("classpath:/static/assets/", "classpath:/static/css/", "classpath:/static/js/", "file:/Users/jiyoon/Documents/upload/");
+
   }
 }


### PR DESCRIPTION
# Spring Security로 인한 정적 자원(부트스트랩) 접근 문제 해결

## 1. 문제 발생
Spring Security 적용 이후, Bootstrap CSS/JS 및 이미지 파일 등 정적 자원이 정상적으로 로드되지 않아  
웹 페이지의 레이아웃이 깨지는 현상이 발생하였다.  
또한, 업로드 파일 접근 경로(`/upload/**`) 역시 차단되어 사용자 측에서 업로드된 파일을 확인할 수 없는 문제가 확인되었다. 

<img src="https://github.com/user-attachments/assets/235287d6-837b-4746-a7d4-457962cd0435" alt="Broken UI Example" height="500" />
---

## 2. 원인 분석
Spring Security는 기본적으로 모든 요청에 대해 인증을 요구한다.  
따라서 정적 자원(`/assets/**`, `/css/**`, `/js/**` 등)과 외부 디렉토리에 매핑된 업로드 파일 경로(`/upload/**`)도  
보안 필터에 의해 차단되면서 발생한 문제이다.  

---

## 3. 해결 방안
- `WebSecurityConfig` 클래스의 `authorizeHttpRequests` 설정에 정적 자원 경로(`/assets/**`, `/css/**`, `/js/**`)를 `permitAll()`로 명시하여 보안 필터를 통과하도록 설정 

````
.authorizeHttpRequests(auth ->
                    auth.requestMatchers("/error", "/login", "/swagger-ui/**", "/v3/api-docs/**").permitAll()
                            .requestMatchers("/assets/**","/css/**","/js/**").permitAll() // bootstrap
                            .requestMatchers("/board/**", "/replies/**", "/view/**", "/upload/**").permitAll()  // board
);
````

- `WebMvcConfigurer`를 활용하여 `/upload/**` 요청을 외부 디렉토리(`/Users/jiyoon/Documents/upload/`)에 매핑하고, 해당 경로 역시 `permitAll()` 처리  

````
registry.addResourceHandler("/assets/**", "/css/**", "/js/**", "/upload/**")
        .addResourceLocations("classpath:/static/assets/", "classpath:/static/css/", "classpath:/static/js/", "file:/Users/jiyoon/Documents/upload/");
````

---

## 4. 적용 결과 및 영향
- Bootstrap 및 기타 정적 자원이 정상적으로 로드되어 웹 페이지의 UI가 정상적으로 표시됨  
- 업로드 파일 경로(`/upload/**`)에 대한 접근이 가능해져 사용자 측에서 업로드 파일 확인 가능  
- 단, 업로드 파일 접근 권한이 모두 열려 있으므로, 필요 시 인증/인가 정책 보완이 요구됨  

<img src="https://github.com/user-attachments/assets/bb5d43f6-085e-4f9b-ad51-61e69b9b268e" alt="Broken UI Example" width="700" />
