### PR TITLE
fix: JWT 관련 cannot find symbol 에러 해결

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -181,7 +181,6 @@
             <groupId>io.jsonwebtoken</groupId>
             <artifactId>jjwt-impl</artifactId>
             <version>0.12.6</version>
-            <scope>runtime</scope>
         </dependency>
 
         <!-- JJWT :: Extensions -->
@@ -189,7 +188,6 @@
             <groupId>io.jsonwebtoken</groupId>
             <artifactId>jjwt-jackson</artifactId>
             <version>0.12.6</version>
-            <scope>runtime</scope>
         </dependency>
     </dependencies>
 

--- a/src/main/java/org/servlet2spring/todo/util/JWTUtil.java
+++ b/src/main/java/org/servlet2spring/todo/util/JWTUtil.java
@@ -62,7 +62,7 @@ public class JWTUtil {
   }
 
   public Map<String, Object> validateToken(String token) throws JwtException {
-    Claims claims = Jwts.parserBuilder()
+    Claims claims = Jwts.parser()
             .setSigningKey(key)
             .build()
             .parseClaimsJws(token)


### PR DESCRIPTION
# JWT 관련 cannot find symbol 에러 해결

## 1. 문제 발생

Spring Security 적용 중 `parserBuilder()` 관련 cannot find symbol 에러 발생

<img width="500" src="https://github.com/user-attachments/assets/9a5cd166-0faa-4813-be59-43df28b29c0f" />


---

## 2. 원인 분석

- `parserBuilder()` 메서드가 Spring Security에서 제공되지 않음
- 잘못된 scope 설정으로 인해 메서드 참조 불가

---

## 3. 해결 방안

- scope 제거  
- `parserBuilder()` → `parse()`로 수정

<img width="500" src="https://github.com/user-attachments/assets/407b143f-c75c-4565-a9c5-8acc2e61fbdf" />


---

## 4. 적용 결과 및 영향

- 정상적으로 JWT 파싱 수행 가능

<img width="200" src="https://github.com/user-attachments/assets/264099e2-9759-4dcc-bdb7-e71f425bc04b" />



## 5. 추가 학습 및 참고
- [Java JWT: JSON Web Token for Java and Android](https://github.com/jwtk/jjwt)
- [cannot find symbol method parserBuilder](https://github.com/jwtk/jjwt/issues/695)
- [Reading a JWT](https://github.com/jwtk/jjwt?tab=readme-ov-file#reading-a-jwt)
