### PR TITLE
fix: Spring Security 404 에러 해결

### DIFF
--- a/src/main/java/org/servlet2spring/todo/config/CustomSecurityConfig.java
+++ b/src/main/java/org/servlet2spring/todo/config/CustomSecurityConfig.java
@@ -76,6 +76,7 @@ public class CustomSecurityConfig {
 
     // APILoginFilter 위치 조정
     // api로 시작하는 모든 경로는 TokenCheckFilter 동작
+    http.addFilterBefore(apiLoginFilter, UsernamePasswordAuthenticationFilter.class);
     http.addFilterBefore(tokenCheckFilter(jwtUtil), UsernamePasswordAuthenticationFilter.class);
 
     // refreshToken 호출 처리


### PR DESCRIPTION
# Spring Security 404 에러 해결

## 1. 문제 발생
TokenCheckFilter를 적용한 이후부터 apiLogin에서 /generateToken을 호출하며 생성되던 토큰이 생성되지 않고 404 에러를 발생시켰다.

<img width="500" alt="image" src="https://github.com/user-attachments/assets/cf3ec394-d98c-4794-a04a-da91eef64b74" />

---

## 2. 원인 분석
### 로그 분석
[generateToken] 버튼 클릭 시 나타나는 로그를 확인했다.

```
16:18:37.470 [http-nio-8080-exec-9] DEBUG org.springframework.security.web.FilterChainProxy - Securing POST /generateToken
16:18:37.472 [http-nio-8080-exec-9] INFO  org.servlet2spring.todo.security.filter.RefreshTokenFilter - skip refresh token filter ----------------------------------------
16:18:37.472 [http-nio-8080-exec-9] DEBUG org.springframework.security.web.authentication.AnonymousAuthenticationFilter - Set SecurityContextHolder to anonymous SecurityContext
16:18:37.472 [http-nio-8080-exec-9] DEBUG org.springframework.security.web.FilterChainProxy - Secured POST /generateToken
16:18:37.477 [http-nio-8080-exec-9] DEBUG org.springframework.security.web.FilterChainProxy - Securing POST /error
16:18:37.477 [http-nio-8080-exec-9] DEBUG org.springframework.security.web.FilterChainProxy - Secured POST /error
16:18:37.481 [http-nio-8080-exec-9] DEBUG org.springframework.security.web.authentication.AnonymousAuthenticationFilter - Set SecurityContextHolder to anonymous SecurityContext
```

POST /generateToken 요청에 대해 Spring Security 필터 체인이 보안 처리를 시작한다. 현재 요청을 처리하는 동안 사용자가 인증되지 않았기 때문에, Spring Security가 임시로 익명(anonymous) 사용자로 설정했다. 그리고 POST /generateToken 요청에 대한 보안 처리가 완료되었지만, 오류가 발생하여 내부적으로 POST /error 엔드포인트로 보안 처리가 발생했다. 

이 로그만으로는 정확한 원인을 알 수 없기에 전체적인 애플리케이션의 동작 맥락을 함께 살펴보았다.


### Spring Security Architecture 구조 분석

스프링 시큐리티는 다음과 같은 과정으로 동작한다.

<img width="500" alt="image" src="https://github.com/user-attachments/assets/ecd420a1-d3bd-4810-9acf-9645a1809aab" />

스프링 시큐리티의 필터 동작을 담당하는 CustomSecurityConfig를 살펴보니 동작 과정도 유사했다. 그러나 TokenCheckFilter를 적용하며 에러가 발생하기에 TokenCheckFilter를 적용한 부분을 위주로 코드를 살펴보았다.

그 결과, /generateToken 요청을 처리하기 위한 APILoginFilter를 SecurityFilterChain에 추가하는 부분이 누락되어 있었다. 이 코드가 없으면 Spring Security는 /generateToken 요청을 처리할 적절한 필터를 찾지 못하고 404 에러를 반환했던 것이다.

---

## 3. 해결 과정
http.addFilterBefore(apiLoginFilter, UsernamePasswordAuthenticationFilter.class)를 추가했다. 이로써 /generateToken 요청이 올바르게 APILoginFilter에 의해 처리되면서 JWT 토큰 발급이 정상적으로 이루어지게 되었다.

````
// 수정 전
http.addFilterBefore(tokenCheckFilter(jwtUtil), UsernamePasswordAuthenticationFilter.class);

// 수정 후
http.addFilterBefore(apiLoginFilter, UsernamePasswordAuthenticationFilter.class);
http.addFilterBefore(tokenCheckFilter(jwtUtil), UsernamePasswordAuthenticationFilter.class);
````

---

## 4. 결과
JWT 토큰이 정상적으로 발급되었다. 

<img width="500" alt="image" src="https://github.com/user-attachments/assets/536eb778-1128-4001-bc9b-3675f6c1dfbe" />

### 참고
- [ChatGPT](https://chatgpt.com)
- [Gemini](https://gemini.google.com/)
- [Dive into the Spring Security Architecture](https://sohailshah20.medium.com/dive-into-the-spring-security-architecture-f35b0af46812)
- [Spring Security란? 사용하는 이유부터 설정 방법까지 알려드립니다!](https://www.elancer.co.kr/blog/detail/235)