### PR TITLE
fix: Spring Security에서 인증정보가 Thymeleaf로 전달되지 않는 에러 해결

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -190,10 +190,10 @@
             <version>0.12.6</version>
         </dependency>
 
-        <!-- Thymeleaf Extras Springsecurity5 -->
+        <!-- Thymeleaf Extras Springsecurity6 -->
         <dependency>
             <groupId>org.thymeleaf.extras</groupId>
-            <artifactId>thymeleaf-extras-springsecurity5</artifactId>
+            <artifactId>thymeleaf-extras-springsecurity6</artifactId>
             <version>3.1.2.RELEASE</version>
         </dependency>
     </dependencies>

--- a/src/main/java/org/servlet2spring/todo/config/CustomSecurityConfig.java
+++ b/src/main/java/org/servlet2spring/todo/config/CustomSecurityConfig.java
@@ -1,7 +1,5 @@
 package org.servlet2spring.todo.config;
 
-import static org.springframework.security.config.Customizer.withDefaults;
-
 import javax.sql.DataSource;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;

--- a/src/main/resources/templates/board/register.html
+++ b/src/main/resources/templates/board/register.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en" xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
       xmlns:th="http://www.thymeleaf.org"
+      xmlns:sec="http://www.thymeleaf.org/extras/spring-security"
       layout:decorate="~{layout/basic.html}">
 <head>
     <meta charset="UTF-8">
@@ -86,6 +87,13 @@
 </div> <!-- layout fragment end -->
 
 <script layout:fragment="script" th:inline="javascript">
+
+    const auth = /*[[${#authentication}]]*/ null;
+    console.log("Authentication object:", auth);
+
+    const username = /*[[${#authentication.name}]]*/ 'anonymous';
+    console.log("Logged-in username:", username);
+
     const errors = [[${errors}]]
     console.log(errors)
 


### PR DESCRIPTION
# Spring Security에서 인증정보가 Thymeleaf로 전달되지 않는 에러 해결

## 1. 문제 발생
현재 로그인한 사용자의 인증 정보를 확인하기 위해 다음 코드를 작성 했지만, 화면단(Thymeleaf)에서 인증 정보를 확인할 수 없었다.

<img width="400" alt="Screenshot 2025-09-23 at 4 04 57 PM" src="https://github.com/user-attachments/assets/2197d686-af97-4177-a69d-6e0257bd653f" />

---

## 2. 원인 분석
### 로그 분석
로그인 시 나타나는 로그를 확인했다.

```
// 사용자(user1) 조회 성공
16:05:52.660 [http-nio-8080-exec-10] INFO  org.servlet2spring.todo.security.CustomUserDetailsService - loadUserByUsername: user1

// 인증 성공
16:05:52.970 [http-nio-8080-exec-10] DEBUG org.springframework.security.authentication.dao.DaoAuthenticationProvider - Authenticated user

// 세션 아이디 갱신, 세션 고정 공격 방지
16:05:52.971 [http-nio-8080-exec-10] DEBUG org.springframework.security.web.authentication.session.ChangeSessionIdAuthenticationStrategy - Changed session id from 965B13C9FC8ED7DB37F350C3B3E8BAC9

// 인증 정보를 세션에 저장
16:05:52.971 [http-nio-8080-exec-10] DEBUG org.springframework.security.web.context.HttpSessionSecurityContextRepository - Stored SecurityContextImpl [Authentication=UsernamePasswordAuthenticationToken [Principal=org.springframework.security.core.userdetails.User [Username=user1, Password=[PROTECTED], Enabled=true, AccountNonExpired=true, CredentialsNonExpired=true, AccountNonLocked=true, Granted Authorities=[ROLE_USER]], Credentials=[PROTECTED], Authenticated=true, Details=WebAuthenticationDetails [RemoteIpAddress=0:0:0:0:0:0:0:1, SessionId=965B13C9FC8ED7DB37F350C3B3E8BAC9], Granted Authorities=[ROLE_USER]]] to HttpSession [org.apache.catalina.session.StandardSessionFacade@6448456]

// Spring Security 내부 인증 컨텍스트에 정상 저장
16:05:52.971 [http-nio-8080-exec-10] DEBUG org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter - Set SecurityContextHolder to UsernamePasswordAuthenticationToken [Principal=org.springframework.security.core.userdetails.User [Username=user1, Password=[PROTECTED], Enabled=true, AccountNonExpired=true, CredentialsNonExpired=true, AccountNonLocked=true, Granted Authorities=[ROLE_USER]], Credentials=[PROTECTED], Authenticated=true, Details=WebAuthenticationDetails [RemoteIpAddress=0:0:0:0:0:0:0:1, SessionId=965B13C9FC8ED7DB37F350C3B3E8BAC9], Granted Authorities=[ROLE_USER]]
16:05:52.971 [http-nio-8080-exec-10] DEBUG org.springframework.security.web.authentication.rememberme.PersistentTokenBasedRememberMeServices - Creating new persistent login for user user1
```

여전히 null로 나타나기에 CustomSecurityConfig 코드 수정을 통해 로그를 확인했다.

```
http.formLogin(form -> form.loginPage("/member/login").successHandler((request, response, authentication) -> {
  log.info("로그인 성공: {}", authentication.getPrincipal());
  response.sendRedirect("/board/register");
}));

//
16:05:52.979 [http-nio-8080-exec-10] INFO  org.servlet2spring.todo.config.CustomSecurityConfig - 로그인 성공: org.springframework.security.core.userdetails.User [Username=user1, Password=[PROTECTED], Enabled=true, AccountNonExpired=true, CredentialsNonExpired=true, AccountNonLocked=true, Granted Authorities=[ROLE_USER]]
16:05:52.991 [http-nio-8080-exec-1] DEBUG org.springframework.security.web.FilterChainProxy - Securing GET /board/register
16:05:52.991 [http-nio-8080-exec-1] DEBUG org.springframework.security.web.context.HttpSessionSecurityContextRepository - Retrieved SecurityContextImpl [Authentication=UsernamePasswordAuthenticationToken [Principal=org.springframework.security.core.userdetails.User [Username=user1, Password=[PROTECTED], Enabled=true, AccountNonExpired=true, CredentialsNonExpired=true, AccountNonLocked=true, Granted Authorities=[ROLE_USER]], Credentials=[PROTECTED], Authenticated=true, Details=WebAuthenticationDetails [RemoteIpAddress=0:0:0:0:0:0:0:1, SessionId=965B13C9FC8ED7DB37F350C3B3E8BAC9], Granted Authorities=[ROLE_USER]]]
16:05:52.991 [http-nio-8080-exec-1] DEBUG org.springframework.security.web.authentication.rememberme.RememberMeAuthenticationFilter - SecurityContextHolder not populated with remember-me token, as it already contained: 'UsernamePasswordAuthenticationToken [Principal=org.springframework.security.core.userdetails.User [Username=user1, Password=[PROTECTED], Enabled=true, AccountNonExpired=true, CredentialsNonExpired=true, AccountNonLocked=true, Granted Authorities=[ROLE_USER]], Credentials=[PROTECTED], Authenticated=true, Details=WebAuthenticationDetails [RemoteIpAddress=0:0:0:0:0:0:0:1, SessionId=965B13C9FC8ED7DB37F350C3B3E8BAC9], Granted Authorities=[ROLE_USER]]'
```
로그에 따르면 POST /member/login 이후 인증은 정상이다. GET /board/register에서도 SecurityContext를 정상적으로 세션에서 불러오는 것 확인된다. 따라서 문제는 Thymeleaf에 있을 가능성이 높다.


---

## 3. 해결 과정

### 의존성 확인

스프링 시큐리티/타임리프 연동 시, #authentication을 쓰려면 thymeleaf-extras-springsecurity 의존성이 필요하다. 그러나 나는 의존성이 추가된 상태에도 계속해서 에러가 발생했기에 버전을 확인했다.

- Spring boot : 3.2.6
- SpringDoc OpenAPI Starter WebMVC UI : 2.5.0
- Spring Boot Starter Security : 3.2.6
- springsecurity5 : 3.1.2

Spring Boot 3은 Spring 6을 기반으로 하고, Spring Security 6과 함께 사용하도록 설계되었다. Spring Security 5는 Spring Security 6과 많은 부분에서 호환되지 않는 변경 사항이 있기에 의존성을 추가한다.

```
<!-- Thymeleaf Extras Springsecurity6 -->
<dependency>
    <groupId>org.thymeleaf.extras</groupId>
    <artifactId>thymeleaf-extras-springsecurity6</artifactId>
    <version>3.1.2.RELEASE</version>
</dependency>
```

정상적으로 화면은 보이지만 여전히 null을 반환한다.

<img width="400" alt="Screenshot 2025-09-23 at 4 04 57 PM" src="https://github.com/user-attachments/assets/2197d686-af97-4177-a69d-6e0257bd653f" />

### Thymeleaf 표현식 확인

Thymeleaf JavaScript comment inlining(/*[[...]]*/)을 사용하여 Spring Security와 직접 연동한다.

```
const auth = /*[[${#authentication}]]*/ null;
console.log("Authentication object:", auth);

const username = /*[[${#authentication.name}]]*/ 'anonymous';
console.log("Logged-in username:", username);
```

---

## 4. 결과
로그인 사용자 정보를 확인할 수 있다.

<img width="500" alt="Screenshot 2025-09-23 at 8 14 59 PM" src="https://github.com/user-attachments/assets/876c01c0-050d-48a1-b3f4-1de6915fab24" />



### 참고
- [ChatGPT](https://chatgpt.com)
- [Gemini](https://gemini.google.com/)
- [spring security 파헤치기 (구조, 인증과정, 설정, 핸들러 및 암호화 예제, @Secured, @AuthenticationPrincipal, taglib)](https://sjh836.tistory.com/165)