### PR TITLE
fix: 카카오 OAuth2 로그인 연동 에러 해결

### DIFF
--- a/src/main/java/org/servlet2spring/todo/security/CustomOAuth2UserService.java
+++ b/src/main/java/org/servlet2spring/todo/security/CustomOAuth2UserService.java
@@ -1,0 +1,23 @@
+package org.servlet2spring.todo.security;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+@Log4j2
+@Service
+@RequiredArgsConstructor
+public class CustomOAuth2UserService extends DefaultOAuth2UserService {
+
+  @Override
+  public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+    log.info("userRequest...");
+    log.info("{}", userRequest);
+
+    return super.loadUser(userRequest);
+  }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -23,3 +23,17 @@ spring.servlet.multipart.max-file-size=100MB
 org.servlet2spring.upload.path=/Users/jiyoon/Documents/upload/
 
 org.org.servlet2spring.jwt.secret=ThisIsASecretKeyForJwtDemo123456!
+
+spring.security.oauth2.client.provider.kakao.authorization-uri=https://kauth.kakao.com/oauth/authorize
+spring.security.oauth2.client.provider.kakao.user-name-attribute=id
+spring.security.oauth2.client.provider.kakao.token-uri=https://kauth.kakao.com/oauth/token
+spring.security.oauth2.client.provider.kakao.user-info-uri=https://kapi.kakao.com/v2/user/me
+
+spring.security.oauth2.client.registration.kakao.client-name=kakao
+spring.security.oauth2.client.registration.kakao.authorization-grant-type=authorization_code
+spring.security.oauth2.client.registration.kakao.redirect-uri=http://localhost:8080/login/oauth2/code/kakao
+spring.security.oauth2.client.registration.kakao.client-id=API ?
+
+spring.security.oauth2.client.registration.kakao.client-secret=
+spring.security.oauth2.client.registration.kakao.client-authentication-method=none
+spring.security.oauth2.client.registration.kakao.scope=profile_nickname


### PR DESCRIPTION
# Spring Security에서 인증정보가 Thymeleaf로 전달되지 않는 에러 해결

## 1. 문제 발생
로그인된 후에 전달하는 정보를 확인하고 싶었지만 다음과 같은 에러가 발생했다.

```
07:54:29.688 [http-nio-8080-exec-4] DEBUG org.springframework.security.web.FilterChainProxy - Securing GET /login/oauth2/code/kakao?code=sJPusDWh6FzbR9CDXQRJGLIUHLilehYliBSPT76JA6q03QFMoXovnAAAAAQKDSKZAAABmaxIs0ZV7imzm104lw&state=co5-w6mBr1tg1b2XayZcOdSCHDDVZXoTLxPsXPQTIB4%3D
07:54:29.697 [http-nio-8080-exec-4] ERROR org.apache.catalina.core.ContainerBase.[Tomcat].[localhost].[/].[dispatcherServlet] - Servlet.service() for servlet [dispatcherServlet] in context with path [] threw exception java.lang.IllegalArgumentException: This class supports client_secret_basic, client_secret_post, and none by default. Client [kakao] is using [POST] instead. Please use a supported client authentication method, or use setRequestEntityConverter to supply an instance that supports [POST]. at org.springframework.util.Assert.isTrue(Assert.java:129) ~[spring-core-6.1.8.jar:6.1.8] at org.springframework.security.oauth2.client.endpoint.ClientAuthenticationMethodValidatingRequest
```

---

## 2. 원인 분석
### 로그 분석
Spring Security 기본 OAuth2AuthorizationCodeGrantRequestEntityConverter 는 client_secret_basic, client_secret_post, none 방식만 지원한다. 설정에서 POST 방식 (client_secret_jwt 같은 커스텀 값)으로 오고 있어서 충돌이 발생했다.

```
// application.properties
spring.security.oauth2.client.registration.kakao.client-id=API 키
spring.security.oauth2.client.registration.kakao.client-authentication-method=POST

// log
This class supports `client_secret_basic`, `client_secret_post`, and `none` by default. 
Client [kakao] is using [POST] instead. 
Please use a supported client authentication method, or use `setRequestEntityConverter` to supply an instance that supports [POST].
```

### Kakao OAuth2 특징
Kakao 로그인은 client_secret 자체를 요구하지 않으므로 OAuth2 표준에서 약간 벗어나 있다. 그렇기에 Spring Security가 지원하지 않는 POST 로 인식한다. 따라서 강제로 none 으로 지정해줘야 정상 동작한다.

---

## 3. 해결 과정

### application.properties 수정

client-secret을 비워두고 client-authentication-method은 none으로 수정한다.

```
spring.security.oauth2.client.registration.kakao.client-secret=
spring.security.oauth2.client.registration.kakao.client-authentication-method=none
```

---

## 4. 결과
로그인 사용자 정보를 확인할 수 있다.

```
10:52:11.980 [http-nio-8080-exec-3] DEBUG org.springframework.security.web.FilterChainProxy - Securing GET /oauth2/authorization/kakao
10:52:12.003 [http-nio-8080-exec-3] DEBUG org.springframework.security.web.DefaultRedirectStrategy - Redirecting to https://kauth.kakao.com/oauth/authorize?response_type=code&client_id=##&scope=profile_nickname&state=##&redirect_uri=http://localhost:8080/login/oauth2/code/kakao&code_challenge=##&code_challenge_method=S256
10:52:12.241 [http-nio-8080-exec-4] DEBUG org.springframework.security.web.FilterChainProxy - Securing GET /login/oauth2/code/kakao?code=##&state=##
10:52:12.593 [http-nio-8080-exec-4] INFO  org.servlet2spring.todo.security.CustomOAuth2UserService - userRequest...
10:52:12.593 [http-nio-8080-exec-4] INFO  org.servlet2spring.todo.security.CustomOAuth2UserService - org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest@##
10:52:12.796 [http-nio-8080-exec-4] DEBUG org.springframework.security.web.authentication.session.ChangeSessionIdAuthenticationStrategy - Changed session id from ##
10:52:12.798 [http-nio-8080-exec-4] DEBUG org.springframework.security.web.context.HttpSessionSecurityContextRepository - Stored SecurityContextImpl [Authentication=OAuth2AuthenticationToken [Principal=Name: [##], Granted Authorities: [[OAUTH2_USER, SCOPE_profile_nickname]], User Attributes: [{id=##, connected_at=2025-10-04T01:23:22Z, properties={nickname=신지윤}, kakao_account={profile_nickname_needs_agreement=false, profile={nickname=신지윤, is_default_nickname=false}}}], Credentials=[PROTECTED], Authenticated=true, Details=WebAuthenticationDetails [RemoteIpAddress=0:0:0:0:0:0:0:1, SessionId=##], Granted Authorities=[OAUTH2_USER, SCOPE_profile_nickname]]] to HttpSession [org.apache.catalina.session.StandardSessionFacade@##]
10:52:12.798 [http-nio-8080-exec-4] DEBUG org.springframework.security.oauth2.client.web.OAuth2LoginAuthenticationFilter - Set SecurityContextHolder to OAuth2AuthenticationToken [Principal=Name: [##], Granted Authorities: [[OAUTH2_USER, SCOPE_profile_nickname]], User Attributes: [{id=##, connected_at=2025-10-04T01:23:22Z, properties={nickname=신지윤}, kakao_account={profile_nickname_needs_agreement=false, profile={nickname=신지윤, is_default_nickname=false}}}], Credentials=[PROTECTED], Authenticated=true, Details=WebAuthenticationDetails [RemoteIpAddress=0:0:0:0:0:0:0:1, SessionId=##], Granted Authorities=[OAUTH2_USER, SCOPE_profile_nickname]]
10:52:12.799 [http-nio-8080-exec-4] DEBUG org.springframework.security.web.authentication.rememberme.PersistentTokenBasedRememberMeServices - Did not send remember-me cookie (principal did not set parameter 'remember-me')
10:52:12.799 [http-nio-8080-exec-4] DEBUG org.springframework.security.web.authentication.rememberme.PersistentTokenBasedRememberMeServices - Remember-me login not requested.
10:52:12.799 [http-nio-8080-exec-4] DEBUG org.springframework.security.web.DefaultRedirectStrategy - Redirecting to /
10:52:12.806 [http-nio-8080-exec-5] DEBUG org.springframework.security.web.FilterChainProxy - Securing GET /
10:52:12.807 [http-nio-8080-exec-5] DEBUG org.springframework.security.web.context.HttpSessionSecurityContextRepository - Retrieved SecurityContextImpl [Authentication=OAuth2AuthenticationToken [Principal=Name: [##], Granted Authorities: [[OAUTH2_USER, SCOPE_profile_nickname]], User Attributes: [{id=##, connected_at=2025-10-04T01:23:22Z, properties={nickname=신지윤}, kakao_account={profile_nickname_needs_agreement=false, profile={nickname=신지윤, is_default_nickname=false}}}], Credentials=[PROTECTED], Authenticated=true, Details=WebAuthenticationDetails [RemoteIpAddress=0:0:0:0:0:0:0:1, SessionId=##], Granted Authorities=[OAUTH2_USER, SCOPE_profile_nickname]]]
10:52:12.808 [http-nio-8080-exec-5] DEBUG org.springframework.security.web.authentication.rememberme.RememberMeAuthenticationFilter - SecurityContextHolder not populated with remember-me token, as it already contained: 'OAuth2AuthenticationToken [Principal=Name: [##], Granted Authorities: [[OAUTH2_USER, SCOPE_profile_nickname]], User Attributes: [{id=##, connected_at=2025-10-04T01:23:22Z, properties={nickname=신지윤}, kakao_account={profile_nickname_needs_agreement=false, profile={nickname=신지윤, is_default_nickname=false}}}], Credentials=[PROTECTED], Authenticated=true, Details=WebAuthenticationDetails [RemoteIpAddress=0:0:0:0:0:0:0:1, SessionId=##], Granted Authorities=[OAUTH2_USER, SCOPE_profile_nickname]]'
```


### 참고
- [ChatGPT](https://chatgpt.com)
- [Gemini](https://gemini.google.com/)